### PR TITLE
Support for `terra`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,5 +17,7 @@ Imports:
     dplyr,
     classInt,
     cowplot,
-    raster,
+    terra,
     magrittr
+Suggests: 
+    raster

--- a/R/bivarmap_map.R
+++ b/R/bivarmap_map.R
@@ -12,6 +12,7 @@
 #' bivariate color matrix, which is optionally also plotted.
 #'
 #' @example examples/bivarmap_map_example.R
+#' @example examples/bivarmap_map_example2.R
 #'
 #' @export
 bivarmap_map <- function(bivarmap,

--- a/R/bivarmap_raster.R
+++ b/R/bivarmap_raster.R
@@ -2,14 +2,16 @@
 #'
 #' Description... documentation to be continued.
 #'
-#' @param rasterx `[RasterLayer,SpatRaster]` \cr RasterLayer representing the
-#' x (first) axis or variable of the bivariate plot.
-#' Support to `SpatRaster` to be added.
-#' @param rastery `[RasterLayer,SpatRaster]` \cr RasterLayer representing the
-#' y (second) axis or variable of the bivariate plot.
-#' Support to `SpatRaster` to be added.
+#' @param rasterx `[RasterLayer,SpatRaster]` \cr `RasterLayer` object (from [raster] package)
+#' or `SpatRaster` (from [terra] package) representing the x (first) axis or variable
+#' of the bivariate plot.
+#' @param rastery `[RasterLayer,SpatRaster]` \cr `RasterLayer` object (from [raster] package)
+#' or `SpatRaster` (from [terra] package) representing the y (second) axis or variable
+#' of the bivariate plot.
 #' @param colmatrix `[matrix]` \cr Matrix of colors to be used in the raster
 #' classification and plot, created with [bivarmap::colmatrix()].
+#' @param export.col.matrix To be documented.
+#' @param outname To be documented
 #'
 #' @return A `RasterLayer` representing the bivariate map classified
 #' accordingly with selected classes for each variable, for bivariate
@@ -19,56 +21,61 @@
 #'
 #' @export
 bivarmap_raster <- function(rasterx, rastery, colmatrix = col.matrix,
-                            export.colour.matrix = TRUE,
+                            export.col.matrix = TRUE,
                             outname = paste0("colMatrix_rasValues", names(rasterx))) {
 
-    # TO DO - replace raster with terra #
-    require(raster)
-    require(classInt)
-
-    # export.colour.matrix will export a data.frame of rastervalues and RGB codes
+    # export.color.matrix will export a data.frame of rastervalues and RGB codes
     # to the global environment outname defines the name of the data.frame
-    quanx <- getValues(rasterx)
+
+    # layer 1
+    quanx <- terra::values(rasterx)
     tempx <- data.frame(quanx, quantile = rep(NA, length(quanx)))
-    brks <- with(tempx, classIntervals(quanx,
-                                       n = attr(colmatrix, "nbreaks"),
-                                       style = attr(colmatrix, "breakstyle"))$brks)
+    brks <- with(tempx,
+                 classInt::classIntervals(quanx,
+                                          n = attr(colmatrix, "nbreaks"),
+                                          style = attr(colmatrix, "breakstyle"))$brks)
+
     ## Add (very) small amount of noise to all but the first break
     ## https://stackoverflow.com/a/19846365/1710632
     brks[-1] <- brks[-1] + seq_along(brks[-1]) * .Machine$double.eps
-    r1 <- within(tempx, quantile <- cut(quanx,
-                                        breaks = brks,
-                                        labels = 2:length(brks),
-                                        include.lowest = TRUE))
+    r1 <- within(tempx,
+                 quantile <- cut(quanx,
+                                 breaks = brks,
+                                 labels = 2:length(brks),
+                                 include.lowest = TRUE))
     quantr <- data.frame(r1[, 2])
-    quany <- getValues(rastery)
+
+    # layer 2
+    quany <- terra::values(rastery)
     tempy <- data.frame(quany, quantile = rep(NA, length(quany)))
-    brksy <- with(tempy, classIntervals(quany,
-                                        n = attr(colmatrix, "nbreaks"),
-                                        style = attr(colmatrix, "breakstyle"))$brks)
+    brksy <- with(tempy,
+                  classInt::classIntervals(quany,
+                                           n = attr(colmatrix, "nbreaks"),
+                                           style = attr(colmatrix, "breakstyle"))$brks)
     brksy[-1] <- brksy[-1] + seq_along(brksy[-1]) * .Machine$double.eps
-    r2 <- within(tempy, quantile <- cut(quany,
-                                        breaks = brksy,
-                                        labels = 2:length(brksy),
-                                        include.lowest = TRUE
-    ))
+    r2 <- within(tempy,
+                 quantile <- cut(quany,
+                                 breaks = brksy,
+                                 labels = 2:length(brksy),
+                                 include.lowest = TRUE))
     quantr2 <- data.frame(r2[, 2])
+
     as.numeric.factor <- function(x) {
         as.numeric(levels(x))[x]
     }
+
     col.matrix2 <- colmatrix
     cn <- unique(colmatrix)
     for (i in 1:length(col.matrix2)) {
         ifelse(is.na(col.matrix2[i]),
-               col.matrix2[i] <- 1, col.matrix2[i] <- which(
-                   col.matrix2[i] == cn
-               )[1]
-        )
+               col.matrix2[i] <- 1,
+               col.matrix2[i] <- which(col.matrix2[i] == cn)[1])
     }
-    # Export the colour.matrix to data.frame() in the global env
+
+    # Export the color.matrix to data.frame() in the global env
     # Can then save with write.table() and use in ArcMap/QGIS
     # Need to save the output raster as integer data-type
-    if (export.colour.matrix) {
+    if (export.col.matrix) {
         # create a dataframe of colours corresponding to raster values
         exportCols <- as.data.frame(cbind(
             as.vector(col.matrix2), as.vector(colmatrix),
@@ -89,7 +96,13 @@ bivarmap_raster <- function(rasterx, rastery, colmatrix = col.matrix,
         b <- as.numeric.factor(quantr2[i, 1])
         cols[i] <- as.numeric(col.matrix2[b, a])
     }
+
+    # classify raster
     r <- rasterx
-    r[1:length(r)] <- cols
+    # r[1:length(r)] <- cols
+    terra::values(r) <- cols
+    names(r) <- "bivarmap"
+
+    # return
     return(r)
 }

--- a/R/data.R
+++ b/R/data.R
@@ -11,13 +11,14 @@
 
 #' Hosts spatial data
 #'
-#' Global raster data with Sarbecovirus bat host species number estimated by ecological niche models for the present. 
+#' Global raster data with Sarbecovirus bat host species number estimated
+#' by ecological niche models for the present.
 #'
 #' @format A Geotiff file. Geographic CRS: WGS84 (+proj=longlat +datum=WGS84 +no_defs).
 #'
 #' @examples
 #' (f <- system.file("raster/hosts.tif", package = "bivarmap"))
-#' raster::raster(f)
+#' terra::rast(f)
 #'
 #' @name hosts.tif
 #'
@@ -26,13 +27,14 @@ NULL
 
 #' Bias data
 #'
-#' Raster data with bias referring to sampling rates (residual bias) based on the distance from occurrences to roads, rivers, airports and cities.
+#' Raster data with bias referring to sampling rates (residual bias) based on the
+#' distance from occurrences to roads, rivers, airports and cities.
 #'
 #' @format A Geotiff file. Geographic CRS: WGS84 (+proj=longlat +datum=WGS84 +no_defs).
 #'
 #' @examples
 #' (f <- system.file("raster/bias.tif", package = "bivarmap"))
-#' raster::raster(f)
+#' terra::rast(f)
 #'
 #' @name bias.tif
 #'

--- a/examples/bivarmap_map_example.R
+++ b/examples/bivarmap_map_example.R
@@ -24,6 +24,3 @@ bivarmap::bivarmap_map(bivarmap = raster_col,
                        y_legend_pos = .1,
                        x_legend_size = .3,
                        y_legend_size = .3)
-
-plot(raster_col)
-plot(temprec)

--- a/examples/bivarmap_map_example2.R
+++ b/examples/bivarmap_map_example2.R
@@ -1,0 +1,51 @@
+#--------------
+# example sarbeco
+library(terra)
+
+rasts_folder <- system.file("raster", package = "bivarmap")
+
+# open hosts raster
+ho <- system.file("raster/hosts.tif", package = "bivarmap")
+hosts <- terra::rast(ho)
+
+# open bias raster
+bi <- system.file("raster/bias.tif", package = "bivarmap")
+bias <- terra::rast(bi)
+
+# resample, since the maps have different resolution
+b <- terra::resample(hosts, bias) %>%
+    c(bias)
+
+# set projection
+terra::crs(b) <- '+proj=longlat +datum=WGS84 +no_defs '
+
+# transorm data to proportions
+b[[1]] <- b[[1]]/ max(na.omit(values(b[[1]])))
+b[[2]] <- b[[2]]/ max(na.omit(values(b[[2]])))
+
+# plot separate rasters
+plot(b, col = viridis::viridis(10))
+
+# color matrix
+colmatrix <- bivarmap::bivarmap_colmatrix(nbreaks = 10,
+                                          upperleft = "cyan",
+                                          upperright = "purple",
+                                          bottomleft = "beige",
+                                          bottomright = "brown1",
+                                          xlab = names(b)[1],
+                                          ylab = names(b)[2])
+colmatrix
+
+# raster
+raster_col <- bivarmap::bivarmap_raster(rasterx = b[[1]],
+                                        rastery = b[[2]],
+                                        colmatrix = colmatrix)
+raster_col
+
+# map
+bivarmap::bivarmap_map(bivarmap = raster_col,
+                       colmat = colmatrix,
+                       x_legend_pos = .01,
+                       y_legend_pos = .1,
+                       x_legend_size = .2,
+                       y_legend_size = .2)

--- a/examples/bivarmap_raster_example.R
+++ b/examples/bivarmap_raster_example.R
@@ -2,6 +2,9 @@
 data("temprec")
 temprec
 
+library(terra)
+temprec <- terra::rast(temprec)
+
 # color matrix
 colmatrix <- bivarmap::bivarmap_colmatrix(nbreaks = 9,
                                           xlab = "Temperatura",
@@ -11,5 +14,11 @@ colmatrix
 # raster
 raster_col <- bivarmap::bivarmap_raster(rasterx = temprec$temp,
                                         rastery = temprec$prec,
-                                        colourmatrix = colmatrix)
+                                        colmatrix = colmatrix)
 raster_col
+
+# plot
+# raster object
+plot(raster::stack(temprec, raster_col))
+# terra object
+plot(c(temprec, raster_col))

--- a/examples/test_package_bivarmap_sarbeco.R
+++ b/examples/test_package_bivarmap_sarbeco.R
@@ -2,23 +2,24 @@
 #devtools::install_github("mauriciovancine/bivarmap", force = TRUE)
 
 # open packages
-library(raster)
+library(terra)
 
 rasts_folder <- system.file("raster", package = "bivarmap")
 
 # open hosts raster
 ho <- system.file("raster/hosts.tif", package = "bivarmap")
-hosts <- raster::raster(ho)
+hosts <- terra::rast(ho)
 
 # open bias raster
 bi <- system.file("raster/bias.tif", package = "bivarmap")
-bias <- raster::raster(bi)
+bias <- terra::rast(bi)
 
 # resample, since the maps have different resolution
-b <- raster::brick(raster::resample(hosts, bias), bias)
+b <- terra::resample(hosts, bias) %>%
+    c(bias)
 
 # set projection
-raster::crs(b) <- '+proj=longlat +datum=WGS84 +no_defs '
+terra::crs(b) <- '+proj=longlat +datum=WGS84 +no_defs '
 
 # transorm data to proportions
 b[[1]] <- b[[1]]/ max(na.omit(values(b[[1]])))
@@ -29,10 +30,10 @@ plot(b, col = viridis::viridis(10))
 
 # color matrix
 colmatrix <- bivarmap::bivarmap_colmatrix(nbreaks = 10,
-                                           upperleft = "cyan",
-                                           upperright = "purple",
-                                           bottomleft = "beige",
-                                           bottomright = "brown1",
+                                          upperleft = "cyan",
+                                          upperright = "purple",
+                                          bottomleft = "beige",
+                                          bottomright = "brown1",
                                           xlab = names(b)[1],
                                           ylab = names(b)[2])
 colmatrix

--- a/examples/test_raster_vs_terra.R
+++ b/examples/test_raster_vs_terra.R
@@ -1,0 +1,67 @@
+# test terra vs raster
+
+#-----
+# using raster input
+
+# data
+data("temprec")
+temprec
+
+temprec <- raster::stack(temprec)
+
+# color matrix
+colmatrix <- bivarmap::bivarmap_colmatrix(nbreaks = 9,
+                                          xlab = "Temperatura",
+                                          ylab = "Precipitação")
+colmatrix
+
+# raster
+raster_col <- bivarmap::bivarmap_raster(rasterx = temprec$temp,
+                                        rastery = temprec$prec,
+                                        colmatrix = colmatrix)
+raster_col
+
+# plot
+plot(raster::stack(temprec, raster_col))
+
+# plot map
+bivarmap::bivarmap_map(bivarmap = raster_col,
+                       colmat = colmatrix,
+                       x_legend_pos = .2,
+                       y_legend_pos = .1,
+                       x_legend_size = .3,
+                       y_legend_size = .3)
+
+#-----
+# using terra input
+# all is the same, just the input is different, and the way to stack
+# in the intermediate plot
+
+# data
+data("temprec")
+temprec
+
+temprec <- terra::rast(temprec)
+
+# color matrix
+colmatrix <- bivarmap::bivarmap_colmatrix(nbreaks = 9,
+                                          xlab = "Temperatura",
+                                          ylab = "Precipitação")
+colmatrix
+
+# raster
+raster_col <- bivarmap::bivarmap_raster(rasterx = temprec$temp,
+                                        rastery = temprec$prec,
+                                        colmatrix = colmatrix)
+raster_col
+
+# plot intermediate raster
+plot(c(temprec, raster_col))
+
+# plot map
+bivarmap::bivarmap_map(bivarmap = raster_col,
+                       colmat = colmatrix,
+                       x_legend_pos = .2,
+                       y_legend_pos = .1,
+                       x_legend_size = .3,
+                       y_legend_size = .3)

--- a/man/bias.tif.Rd
+++ b/man/bias.tif.Rd
@@ -5,19 +5,16 @@
 \title{Bias data}
 \format{
 A Geotiff file. Geographic CRS: WGS84 (+proj=longlat +datum=WGS84 +no_defs).
-\itemize{
-\item{1:} {Presence of cabins}
-\item{NA:} {No presence of cabins}
-}
 }
 \source{
-\url{to_complete_here}
+\url{https://www.biorxiv.org/content/10.1101/2021.12.09.471691v1}
 }
 \description{
-Raster data with bias from species distribution models. Bias here represents...
+Raster data with bias referring to sampling rates (residual bias) based on the
+distance from occurrences to roads, rivers, airports and cities.
 }
 \examples{
 (f <- system.file("raster/bias.tif", package = "bivarmap"))
-raster::raster(f)
+terra::rast(f)
 
 }

--- a/man/bivarmap_map.Rd
+++ b/man/bivarmap_map.Rd
@@ -39,7 +39,7 @@ temprec
 # color matrix
 colmatrix <- bivarmap::bivarmap_colmatrix(nbreaks = 9,
                                           xlab = "Temperatura",
-                                          ylab = "PrecipitaÃ§Ã£o")
+                                          ylab = "Precipitação")
 colmatrix
 
 # raster
@@ -55,7 +55,55 @@ bivarmap::bivarmap_map(bivarmap = raster_col,
                        y_legend_pos = .1,
                        x_legend_size = .3,
                        y_legend_size = .3)
+#--------------
+# example sarbeco
+library(terra)
 
-plot(raster_col)
-plot(temprec)
+rasts_folder <- system.file("raster", package = "bivarmap")
+
+# open hosts raster
+ho <- system.file("raster/hosts.tif", package = "bivarmap")
+hosts <- terra::rast(ho)
+
+# open bias raster
+bi <- system.file("raster/bias.tif", package = "bivarmap")
+bias <- terra::rast(bi)
+
+# resample, since the maps have different resolution
+b <- terra::resample(hosts, bias) \%>\%
+    c(bias)
+
+# set projection
+terra::crs(b) <- '+proj=longlat +datum=WGS84 +no_defs '
+
+# transorm data to proportions
+b[[1]] <- b[[1]]/ max(na.omit(values(b[[1]])))
+b[[2]] <- b[[2]]/ max(na.omit(values(b[[2]])))
+
+# plot separate rasters
+plot(b, col = viridis::viridis(10))
+
+# color matrix
+colmatrix <- bivarmap::bivarmap_colmatrix(nbreaks = 10,
+                                          upperleft = "cyan",
+                                          upperright = "purple",
+                                          bottomleft = "beige",
+                                          bottomright = "brown1",
+                                          xlab = names(b)[1],
+                                          ylab = names(b)[2])
+colmatrix
+
+# raster
+raster_col <- bivarmap::bivarmap_raster(rasterx = b[[1]],
+                                        rastery = b[[2]],
+                                        colmatrix = colmatrix)
+raster_col
+
+# map
+bivarmap::bivarmap_map(bivarmap = raster_col,
+                       colmat = colmatrix,
+                       x_legend_pos = .01,
+                       y_legend_pos = .1,
+                       x_legend_size = .2,
+                       y_legend_size = .2)
 }

--- a/man/bivarmap_raster.Rd
+++ b/man/bivarmap_raster.Rd
@@ -8,21 +8,25 @@ bivarmap_raster(
   rasterx,
   rastery,
   colmatrix = col.matrix,
-  export.colour.matrix = TRUE,
+  export.col.matrix = TRUE,
   outname = paste0("colMatrix_rasValues", names(rasterx))
 )
 }
 \arguments{
-\item{rasterx}{\verb{[RasterLayer,SpatRaster]} \cr RasterLayer representing the
-x (first) axis or variable of the bivariate plot.
-Support to \code{SpatRaster} to be added.}
+\item{rasterx}{\verb{[RasterLayer,SpatRaster]} \cr \code{RasterLayer} object (from \link{raster} package)
+or \code{SpatRaster} (from \link{terra} package) representing the x (first) axis or variable
+of the bivariate plot.}
 
-\item{rastery}{\verb{[RasterLayer,SpatRaster]} \cr RasterLayer representing the
-y (second) axis or variable of the bivariate plot.
-Support to \code{SpatRaster} to be added.}
+\item{rastery}{\verb{[RasterLayer,SpatRaster]} \cr \code{RasterLayer} object (from \link{raster} package)
+or \code{SpatRaster} (from \link{terra} package) representing the y (second) axis or variable
+of the bivariate plot.}
 
 \item{colmatrix}{\verb{[matrix]} \cr Matrix of colors to be used in the raster
 classification and plot, created with \code{\link[=colmatrix]{colmatrix()}}.}
+
+\item{export.col.matrix}{To be documented.}
+
+\item{outname}{To be documented}
 }
 \value{
 A \code{RasterLayer} representing the bivariate map classified

--- a/man/hosts.tif.Rd
+++ b/man/hosts.tif.Rd
@@ -5,19 +5,16 @@
 \title{Hosts spatial data}
 \format{
 A Geotiff file. Geographic CRS: WGS84 (+proj=longlat +datum=WGS84 +no_defs).
-\itemize{
-\item{1:} {Presence of cabins}
-\item{NA:} {No presence of cabins}
-}
 }
 \source{
-\url{to_complete_here}
+\url{https://www.biorxiv.org/content/10.1101/2021.12.09.471691v1}
 }
 \description{
-Global raster data with info from hosts...
+Global raster data with Sarbecovirus bat host species number estimated
+by ecological niche models for the present.
 }
 \examples{
 (f <- system.file("raster/hosts.tif", package = "bivarmap"))
-raster::raster(f)
+terra::rast(f)
 
 }


### PR DESCRIPTION
Oi pessoal,

O prinicpal nesse PR foi prover suporte ao pacote `terra`. O bom é que boa parte das funcoes do `terra` funciona também para objectos `raster`, como `terra::values()`.
- Modifiquei isso na funcao `bivarmap_raster()`. Agora ela aceita inputs `RasterLayer` ou inputs `SpatRaster`. 
- Mas vale a pena testar. Adaptei os exemplos anteriores, assim como o exemplos da Sarbeco. Tambem adicionei um script comparando `terra` e `raster`, [aqui](https://github.com/bniebuhr/bivarmap/blob/main/examples/test_raster_vs_terra.R).
- Quanto ao exemplo da Sarbeco, copiei o essencial dele e renomeei como `bivarplot_map_example2.R`. Mas o outro se mantem la, podemos usar mais livremente como exemplo, independentemente da documentacao das funcoes.
- Nome do output da funcao `bivarmap_raster()`: estava saindo com o mesmo nome do rasterx (no nosso exemplo inicial, "temp"). Eu muei o nome para "bivarmap" meio generico, mas podemos mudar para o que for melhor.
- também retirei todas as dependências do tipo `require(raster)` de dentro das funcoes. O recomendado é usar, ao invés disso, `raster::` antes das funcoes, e adicionar os pacotes essenciais no documento DESCRIPTION.